### PR TITLE
Refactor parsers

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -5,187 +5,23 @@
 // Part of the TMRW Manifesto for user-owned, unchained infrastructure.
 // Copyright (c) 2025 tmrw.it | MIT License
 
-import fs from "fs-extra";
-import path from "path";
-import hcl from "hcl2-parser";
-import yaml from "js-yaml";
+import path from "node:path";
 import chalk from "chalk";
 import type { ScanResults, VendorService } from "./types";
 export { ScanResults, VendorService } from "./types";
+import type { ParsedData } from "./parsers";
+import {
+  parseTerraformFile,
+  parseYamlFile,
+  parseCloudFormationFile,
+  parsePackageJsonFile,
+} from "./parsers";
 
 // Load vendor services data for scoring and portability checks
-const vendorServices: Record<string, VendorService[]> = require("../data/vendor-services.json");
-
-// Define the structure for data returned by parsing functions
-type ParsedData = {
-  providers: string[];        // List of detected cloud providers (e.g., "aws", "azure")
-  services: string[];         // List of detected services (e.g., "aws_lambda_function", "docker")
-  highRiskIncrement: number;  // Incremental risk score for specific high-risk services
-};
-
-/**
- * Parses a Terraform (.tf) file to extract provider and service information.
- * @param filePath - Path to the Terraform file.
- * @returns An object containing providers, services, and a high-risk increment (0 for Terraform).
- */
-async function parseTerraformFile(filePath: string): Promise<ParsedData> {
-  const content = await fs.readFile(filePath, "utf8");
-  let parsed: any;
-  try {
-    parsed = hcl.parse(content);
-  } catch (err) {
-    if (process.env.DEBUG === "true") {
-      console.warn(chalk.yellow(`Skipping invalid Terraform file: ${filePath}`));
-    }
-    return { providers: [], services: [], highRiskIncrement: 0 };
-  }
-
-  // Extract providers from "provider" blocks (e.g., "aws", "azure")
-  const providers = parsed.body
-    .filter((b: any) => b.provider)
-    .map((b: any) => b.provider);
-
-  // Extract services from "resource" blocks (e.g., "aws_lambda_function")
-  const services = parsed.body
-    .filter((b: any) => b.resource)
-    .map((b: any) => b.resource.type);
-
-  return { providers, services, highRiskIncrement: 0 };
-}
-
-/**
- * Parses a YAML (.yml/.yaml) file to detect providers, services, and portable standards.
- * Handles serverless frameworks, docker-compose, and Helm charts.
- * @param filePath - Path to the YAML file.
- * @returns An object containing providers, services, and a high-risk increment for serverless functions.
- */
-async function parseYamlFile(filePath: string): Promise<ParsedData> {
-  const content = await fs.readFile(filePath, "utf8");
-  let config: any;
-  try {
-    config = yaml.load(content);
-  } catch (err) {
-    if (process.env.DEBUG === "true") {
-      console.warn(chalk.yellow(`Skipping invalid YAML file: ${filePath}`));
-    }
-    return { providers: [], services: [], highRiskIncrement: 0 };
-  }
-
-  const providers: string[] = [];
-  let services: string[] = [];
-  let highRiskIncrement = 0;
-
-  // Detect serverless framework usage (e.g., AWS Serverless Framework)
-  if (config.provider?.name) {
-    providers.push(config.provider.name);
-
-    const fnObj = config.functions || {};
-    const functionCount = Array.isArray(fnObj)
-      ? fnObj.length
-      : Object.keys(fnObj).length;
-
-    const serviceNameMap: Record<string, string> = {
-      aws: "aws_lambda_function",
-      azure: "azurerm_function_app",
-      gcp: "google_cloud_functions",
-      ibm: "ibm_cloud_function",
-      oracle: "oci_functions_function",
-    };
-
-    const serviceName =
-      serviceNameMap[config.provider.name] ||
-      `${config.provider.name}_function`;
-
-    services.push(...Array(functionCount).fill(serviceName));
-    highRiskIncrement = functionCount * 0.2; // Each function adds 0.2 to high-risk score
-  }
-
-  // Detect docker-compose files (assumed portable)
-  if (path.basename(filePath).includes("docker-compose")) {
-    const serviceCount = Object.keys(config.services || {}).length;
-    services = Array(serviceCount).fill("docker"); // One "docker" service per defined service
-  }
-
-  // Detect Helm charts based on specific keys
-  if (config.apiVersion && typeof config.apiVersion === "string" && config.apiVersion.includes("helm.sh")) {
-    services.push("helm"); // Helm is considered portable
-  }
-  if (config.kind && config.kind === "Chart") {
-    services.push("helm");
-  }
-
-  return { providers, services, highRiskIncrement };
-}
-
-/**
- * Parses a CloudFormation JSON file to identify AWS services.
- * @param filePath - Path to the JSON file.
- * @returns An object containing providers and services if it's a valid CloudFormation template.
- */
-async function parseCloudFormationFile(filePath: string): Promise<ParsedData> {
-  let cfTemplate: any;
-  try {
-    cfTemplate = await fs.readJson(filePath);
-  } catch (err) {
-    if (process.env.DEBUG === "true") {
-      console.warn(chalk.yellow(`Skipping invalid JSON file: ${filePath}`));
-    }
-    return { providers: [], services: [], highRiskIncrement: 0 };
-  }
-
-  // Verify it's a CloudFormation template by checking for "Resources"
-  if (!cfTemplate.Resources || typeof cfTemplate.Resources !== "object") {
-    return { providers: [], services: [], highRiskIncrement: 0 };
-  }
-
-  const providers: string[] = [];
-  const services: string[] = [];
-
-  // Parse each resource to detect AWS services
-  for (const resourceKey of Object.keys(cfTemplate.Resources)) {
-    const resourceObj = cfTemplate.Resources[resourceKey];
-    if (resourceObj.Type && typeof resourceObj.Type === "string") {
-      const typePath = resourceObj.Type.split("::");
-      if (typePath[0] === "AWS") {
-        providers.push("aws");
-        const guessedName = typePath.join("_").toLowerCase(); // e.g., "AWS::Lambda::Function" -> "aws_lambda_function"
-        services.push(guessedName);
-      }
-    }
-  }
-
-  return { providers, services, highRiskIncrement: 0 };
-}
-
-/**
- * Parses a package.json file to detect cloud provider dependencies.
- * @param filePath - Path to the package.json file.
- * @returns An object containing providers, services, and a high-risk increment for cloud dependencies.
- */
-async function parsePackageJsonFile(filePath: string): Promise<ParsedData> {
-  const pkg = await fs.readJson(filePath);
-  const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-  const providers: string[] = [];
-  const services: string[] = [];
-  let highRiskIncrement = 0;
-
-  // Check for AWS dependencies
-  if (deps["aws-sdk"] || deps["@aws-sdk/client-s3"]) {
-    providers.push("aws");
-    services.push("aws_sdk");
-    highRiskIncrement += 0.1; // Arbitrary risk increment per cloud dependency
-  }
-
-  // Check for Azure dependencies
-  if (deps["@azure/storage-blob"]) {
-    providers.push("azure");
-    services.push("azure_blob");
-    highRiskIncrement += 0.1;
-  }
-
-  // Additional dependency checks can be added here
-  return { providers, services, highRiskIncrement };
-}
+const vendorServices: Record<
+  string,
+  VendorService[]
+> = require("../data/vendor-services.json");
 
 /**
  * Analyzes a list of files to compute the Freedom Score and assess cloud-related risks.
@@ -193,12 +29,14 @@ async function parsePackageJsonFile(filePath: string): Promise<ParsedData> {
  * @param rootDir - Root directory of the codebase.
  * @returns A promise resolving to the ScanResults object with scores and risk assessments.
  */
-export async function analyzeFiles(files: string[], rootDir: string): Promise<ScanResults> {
-  const vendorServicesFound: string[] = []; // All detected services
-  const providers = new Set<string>();      // Unique set of providers
-  let highRiskServices = 0;               // Accumulated high-risk score
+export async function analyzeFiles(
+  files: string[],
+  rootDir: string,
+): Promise<ScanResults> {
+  const vendorServicesFound: string[] = [];
+  const providers = new Set<string>();
+  let highRiskServices = 0;
 
-  // Process each file based on its type
   for (const file of files) {
     const filePath = path.join(rootDir, file);
     try {
@@ -212,16 +50,18 @@ export async function analyzeFiles(files: string[], rootDir: string): Promise<Sc
       } else if (file.endsWith("package.json")) {
         parsedData = await parsePackageJsonFile(filePath);
       } else {
-        continue; // Skip unsupported file types
+        continue;
       }
-
-      // Aggregate providers and services
-      parsedData.providers.forEach((p) => providers.add(p));
+      for (const p of parsedData.providers) {
+        providers.add(p);
+      }
       vendorServicesFound.push(...parsedData.services);
       highRiskServices += parsedData.highRiskIncrement;
     } catch (err) {
       if (process.env.DEBUG === "true") {
-        console.warn(chalk.yellow(`Error processing ${file}: ${(err as Error).message}`));
+        console.warn(
+          chalk.yellow(`Error processing ${file}: ${(err as Error).message}`),
+        );
       }
     }
   }
@@ -230,29 +70,23 @@ export async function analyzeFiles(files: string[], rootDir: string): Promise<Sc
   let lockInScore = 0;
   let openStandardsCount = 0;
 
-  // Evaluate each service for lock-in, portability, and risk
-  vendorServicesFound.forEach((service) => {
+  for (const service of vendorServicesFound) {
     const vendorService = Object.values(vendorServices)
       .flat()
       .find((s) => s.name === service);
     if (vendorService) {
-      lockInScore += vendorService.lockInScore; // Sum lock-in scores
+      lockInScore += vendorService.lockInScore;
       if (vendorService.deplatformRisk > 0.3) {
-        highRiskServices += 1; // Increment for services with high deplatforming risk
+        highRiskServices += 1;
       }
       if (vendorServices.portable.some((s) => s.name === service)) {
-        openStandardsCount += 1; // Count portable services (e.g., "docker", "helm")
+        openStandardsCount += 1;
       }
     }
-  });
+  }
 
-  // Normalize lock-in score to a 0-100 scale
   lockInScore = totalServices ? (lockInScore / totalServices) * 100 : 0;
 
-  // Calculate deplatforming risk score
-  // - Single provider penalty: 50 if only one provider is detected
-  // - High-risk penalty: 20 points per high-risk service or fraction thereof
-  // - Redundancy penalty: 30 if only one provider (no redundancy)
   const singleProviderPenalty = providers.size === 1 ? 50 : 0;
   const highRiskPenalty = highRiskServices * 20;
   const redundancyPenalty = providers.size === 1 ? 30 : 0;
@@ -261,13 +95,10 @@ export async function analyzeFiles(files: string[], rootDir: string): Promise<Sc
     singleProviderPenalty + highRiskPenalty + redundancyPenalty,
   );
 
-  // Calculate portability score as the fraction of services using open standards
-  const portabilityScore = totalServices ? openStandardsCount / totalServices : 0;
+  const portabilityScore = totalServices
+    ? openStandardsCount / totalServices
+    : 0;
 
-  // Calculate Freedom Score: 100 minus weighted penalties
-  // - Lock-in penalty: 50% of lockInScore
-  // - Deplatforming penalty: 30% of deplatformingRiskScore
-  // - Proprietary format penalty: 20% of (1 - portabilityScore)
   const freedomScore = Math.round(
     100 -
       lockInScore * 0.5 -
@@ -282,9 +113,18 @@ export async function analyzeFiles(files: string[], rootDir: string): Promise<Sc
     portabilityScore,
     vendorServices: vendorServicesFound,
     providers: Array.from(providers),
-    riskLabel: freedomScore < 50 ? "VULNERABLE" : freedomScore <= 75 ? "AT RISK" : "CAUTIOUS",
+    riskLabel:
+      freedomScore < 50
+        ? "VULNERABLE"
+        : freedomScore <= 75
+          ? "AT RISK"
+          : "CAUTIOUS",
     deplatformingRisk:
-      deplatformingRiskScore > 70 ? "HIGH" : deplatformingRiskScore > 30 ? "Moderate" : "Low",
+      deplatformingRiskScore > 70
+        ? "HIGH"
+        : deplatformingRiskScore > 30
+          ? "Moderate"
+          : "Low",
     recommendations: [
       "Ditch proprietary services like Lambda for Dockerized functions. Run them anywhere.",
       "Replace vendor-locked storage like S3 with MinIO or self-hosted solutions. Own your data.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,9 @@ interface AuditOptions {
  * @returns A promise resolving to the scan results, including Freedom Score, risks, and recommendations.
  * @throws Error if the scan fails or no files are found.
  */
-export async function runAudit(options: AuditOptions = {}): Promise<ScanResults> {
+export async function runAudit(
+  options: AuditOptions = {},
+): Promise<ScanResults> {
   const dir = options.dir || process.cwd();
   return await scanCodebase({
     dir,
@@ -43,7 +45,9 @@ export async function runAudit(options: AuditOptions = {}): Promise<ScanResults>
  * @param file - Path to the report file (defaults to ./tmrw-audit-report.json).
  * @throws Error if reading or displaying the report fails.
  */
-export async function getReport(file = "./tmrw-audit-report.json"): Promise<void> {
+export async function getReport(
+  file = "./tmrw-audit-report.json",
+): Promise<void> {
   await displayReport(file);
 }
 
@@ -54,27 +58,43 @@ dotenv.config();
 program
   .command("audit")
   .description(
-    "Scan your codebase to calculate your Freedom Score and identify cloud vendor lock-in risks. This command analyzes your infrastructure files (e.g., Terraform, YAML, package.json) and provides actionable recommendations to reduce dependency on specific cloud providers."
+    "Scan your codebase to calculate your Freedom Score and identify cloud vendor lock-in risks. This command analyzes your infrastructure files (e.g., Terraform, YAML, package.json) and provides actionable recommendations to reduce dependency on specific cloud providers.",
   )
-  .option("-o, --output <path>", "Specify the output path for the report", "./tmrw-audit-report.json")
-  .option("-p, --patterns <patterns>", "Comma-separated file patterns to scan (e.g., *.tf,*.yml)")
+  .option(
+    "-o, --output <path>",
+    "Specify the output path for the report",
+    "./tmrw-audit-report.json",
+  )
+  .option(
+    "-p, --patterns <patterns>",
+    "Comma-separated file patterns to scan (e.g., *.tf,*.yml)",
+  )
   .option("-v, --verbose", "Enable verbose logging for scanning details")
   .action(async (cmd) => {
     try {
       const results = await runAudit({
         output: cmd.output,
-        filePatterns: cmd.patterns ? cmd.patterns.split(",").map((p: string) => p.trim()) : undefined,
+        filePatterns: cmd.patterns
+          ? cmd.patterns.split(",").map((p: string) => p.trim())
+          : undefined,
         verbose: cmd.verbose,
       });
       console.log(chalk.red.bold("AUDIT COMPLETE: YOUR INFRA’S FATE EXPOSED"));
-      const riskColor = results.riskLabel === "VULNERABLE" ? chalk.red :
-                        results.riskLabel === "AT RISK" ? chalk.yellow :
-                        chalk.green;
-      console.log(`Freedom Score: ${riskColor(`${results.freedomScore}/100 (${results.riskLabel})`)}`);
+      const riskColor =
+        results.riskLabel === "VULNERABLE"
+          ? chalk.red
+          : results.riskLabel === "AT RISK"
+            ? chalk.yellow
+            : chalk.green;
+      console.log(
+        `Freedom Score: ${riskColor(`${results.freedomScore}/100 (${results.riskLabel})`)}`,
+      );
       console.log(`Vendor Lock-In: ${results.lockInScore.toFixed(1)}%`);
       console.log(`Deplatforming Risk: ${results.deplatformingRisk}`);
       console.log(chalk.bold("Recommendations:"));
-      results.recommendations.forEach(rec => console.log(chalk.cyan(`- ${rec}`)));
+      for (const rec of results.recommendations) {
+        console.log(chalk.cyan(`- ${rec}`));
+      }
       const reportPath = await generateReport(results, cmd.output);
       console.log(`Report saved to: ${reportPath}`);
       console.log(chalk.dim("For a detailed breakdown, run `tmrw report`"));
@@ -87,7 +107,7 @@ program
 program
   .command("report [file]")
   .description(
-    "Display a previously saved audit report. Use this command to review your Freedom Score, vendor lock-in details, deplatforming risks, and recommendations without rescanning the codebase. Optionally, specify a report file path (default: ./tmrw-audit-report.json)."
+    "Display a previously saved audit report. Use this command to review your Freedom Score, vendor lock-in details, deplatforming risks, and recommendations without rescanning the codebase. Optionally, specify a report file path (default: ./tmrw-audit-report.json).",
   )
   .action(async (file) => {
     try {
@@ -101,11 +121,15 @@ program
 program
   .command("escape")
   .description(
-    "Get instructions on deploying the Sovereign Stack, a set of tools and practices for building resilient, user-owned infrastructure. This command provides a link to the Sovereign Stack deployment guide and the Escape Plan."
+    "Get instructions on deploying the Sovereign Stack, a set of tools and practices for building resilient, user-owned infrastructure. This command provides a link to the Sovereign Stack deployment guide and the Escape Plan.",
   )
   .action(() => {
-    console.log(chalk.cyan("Deploy the Sovereign Stack: https://tmrw.it/stack"));
-    console.log(chalk.cyan("Follow the Escape Plan to build user-owned infrastructure."));
+    console.log(
+      chalk.cyan("Deploy the Sovereign Stack: https://tmrw.it/stack"),
+    );
+    console.log(
+      chalk.cyan("Follow the Escape Plan to build user-owned infrastructure."),
+    );
   });
 
 program.parse(process.argv);

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,0 +1,175 @@
+// tmrw audit - Parsing Helpers
+// Why this exists: We split parsing logic into its own module.
+// What it does: Provides functions that detect providers and services in common infra files.
+// How it works: Each helper reads a file type, extracts names and returns them for scoring.
+// Part of the TMRW Manifesto for user-owned, unchained infrastructure.
+// Copyright (c) 2025 tmrw.it | MIT License
+
+import fs from "fs-extra";
+import path from "node:path";
+import hcl from "hcl2-parser";
+import yaml from "js-yaml";
+import chalk from "chalk";
+
+/** Parsed data returned by each parser */
+export interface ParsedData {
+  /** Detected cloud providers (e.g., aws, azure) */
+  providers: string[];
+  /** Detected service names (e.g., aws_lambda_function, docker) */
+  services: string[];
+  /** Risk increment for high-risk services */
+  highRiskIncrement: number;
+}
+
+/** Parse a Terraform (.tf) file */
+export async function parseTerraformFile(
+  filePath: string,
+): Promise<ParsedData> {
+  const content = await fs.readFile(filePath, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = hcl.parse(content);
+  } catch {
+    if (process.env.DEBUG === "true") {
+      console.warn(
+        chalk.yellow(`Skipping invalid Terraform file: ${filePath}`),
+      );
+    }
+    return { providers: [], services: [], highRiskIncrement: 0 };
+  }
+
+  const body = (parsed as { body: Array<Record<string, unknown>> }).body ?? [];
+  const providers = body
+    .filter((b) => "provider" in b)
+    .map((b) => (b as { provider: string }).provider);
+  const services = body
+    .filter((b) => "resource" in b)
+    .map((b) => (b as { resource: { type: string } }).resource.type);
+  return { providers, services, highRiskIncrement: 0 };
+}
+
+/** Parse a YAML (.yml/.yaml) file */
+export async function parseYamlFile(filePath: string): Promise<ParsedData> {
+  const content = await fs.readFile(filePath, "utf8");
+  let config: unknown;
+  try {
+    config = yaml.load(content);
+  } catch {
+    if (process.env.DEBUG === "true") {
+      console.warn(chalk.yellow(`Skipping invalid YAML file: ${filePath}`));
+    }
+    return { providers: [], services: [], highRiskIncrement: 0 };
+  }
+
+  const providers: string[] = [];
+  let services: string[] = [];
+  let highRiskIncrement = 0;
+
+  const cfg = config as {
+    provider?: { name?: string };
+    functions?: unknown;
+    services?: unknown;
+    apiVersion?: string;
+    kind?: string;
+  };
+
+  if (cfg.provider?.name) {
+    providers.push(cfg.provider.name);
+    const fnObj = cfg.functions || {};
+    const functionCount = Array.isArray(fnObj)
+      ? fnObj.length
+      : Object.keys(fnObj).length;
+    const serviceNameMap: Record<string, string> = {
+      aws: "aws_lambda_function",
+      azure: "azurerm_function_app",
+      gcp: "google_cloud_functions",
+      ibm: "ibm_cloud_function",
+      oracle: "oci_functions_function",
+    };
+    const serviceName =
+      serviceNameMap[cfg.provider.name] || `${cfg.provider.name}_function`;
+    services.push(...Array(functionCount).fill(serviceName));
+    highRiskIncrement = functionCount * 0.2;
+  }
+
+  if (path.basename(filePath).includes("docker-compose")) {
+    const serviceCount = Object.keys(cfg.services || {}).length;
+    services = Array(serviceCount).fill("docker");
+  }
+
+  if (
+    cfg.apiVersion &&
+    typeof cfg.apiVersion === "string" &&
+    cfg.apiVersion.includes("helm.sh")
+  ) {
+    services.push("helm");
+  }
+  if (cfg.kind && cfg.kind === "Chart") {
+    services.push("helm");
+  }
+
+  return { providers, services, highRiskIncrement };
+}
+
+/** Parse a CloudFormation JSON file */
+export async function parseCloudFormationFile(
+  filePath: string,
+): Promise<ParsedData> {
+  let cfTemplate: unknown;
+  try {
+    cfTemplate = await fs.readJson(filePath);
+  } catch {
+    if (process.env.DEBUG === "true") {
+      console.warn(chalk.yellow(`Skipping invalid JSON file: ${filePath}`));
+    }
+    return { providers: [], services: [], highRiskIncrement: 0 };
+  }
+
+  const template = cfTemplate as {
+    Resources?: Record<string, { Type?: string }>;
+  };
+  if (!template.Resources || typeof template.Resources !== "object") {
+    return { providers: [], services: [], highRiskIncrement: 0 };
+  }
+
+  const providers: string[] = [];
+  const services: string[] = [];
+
+  for (const key of Object.keys(template.Resources)) {
+    const resourceObj = template.Resources[key];
+    if (resourceObj.Type && typeof resourceObj.Type === "string") {
+      const typePath = resourceObj.Type.split("::");
+      if (typePath[0] === "AWS") {
+        providers.push("aws");
+        services.push(typePath.join("_").toLowerCase());
+      }
+    }
+  }
+
+  return { providers, services, highRiskIncrement: 0 };
+}
+
+/** Parse a package.json file */
+export async function parsePackageJsonFile(
+  filePath: string,
+): Promise<ParsedData> {
+  const pkg = await fs.readJson(filePath);
+  const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+  const providers: string[] = [];
+  const services: string[] = [];
+  let highRiskIncrement = 0;
+
+  if (deps["aws-sdk"] || deps["@aws-sdk/client-s3"]) {
+    providers.push("aws");
+    services.push("aws_sdk");
+    highRiskIncrement += 0.1;
+  }
+
+  if (deps["@azure/storage-blob"]) {
+    providers.push("azure");
+    services.push("azure_blob");
+    highRiskIncrement += 0.1;
+  }
+
+  return { providers, services, highRiskIncrement };
+}

--- a/src/report.ts
+++ b/src/report.ts
@@ -46,28 +46,52 @@ export async function displayReport(
     console.log(`Timestamp: ${report.timestamp}`);
 
     // Color for risk label based on severity
-    const riskColor = report.riskLabel === "VULNERABLE" ? chalk.red :
-      report.riskLabel === "AT RISK" ? chalk.yellow :
-      chalk.green;
-    console.log(chalk.bold(`Freedom Score: ${report.freedomScore}/100 (${riskColor(report.riskLabel)})`));
+    const riskColor =
+      report.riskLabel === "VULNERABLE"
+        ? chalk.red
+        : report.riskLabel === "AT RISK"
+          ? chalk.yellow
+          : chalk.green;
+    console.log(
+      chalk.bold(
+        `Freedom Score: ${report.freedomScore}/100 (${riskColor(report.riskLabel)})`,
+      ),
+    );
 
     console.log(`Vendor Lock-In: ${report.lockInScore}%`);
 
     // Color for deplatforming risk based on level
-    const deplatformColor = report.deplatformingRisk === "HIGH" ? chalk.red :
-      report.deplatformingRisk === "Moderate" ? chalk.yellow :
-      chalk.green;
-    console.log(`Deplatforming Risk: ${deplatformColor(report.deplatformingRisk)}`);
+    const deplatformColor =
+      report.deplatformingRisk === "HIGH"
+        ? chalk.red
+        : report.deplatformingRisk === "Moderate"
+          ? chalk.yellow
+          : chalk.green;
+    console.log(
+      `Deplatforming Risk: ${deplatformColor(report.deplatformingRisk)}`,
+    );
 
     // Separator
     console.log(chalk.dim("—".repeat(50)));
 
     // Freedom Score Calculation
     console.log(chalk.dim("Freedom Score Calculation:"));
-    console.log(`Base Score: 100`);
-    console.log(chalk.red(`- Vendor Lock-In Penalty: ${(report.lockInScore * 0.5).toFixed(1)}`));
-    console.log(chalk.red(`- Deplatforming Risk Penalty: ${(report.deplatformingRiskScore * 0.3).toFixed(1)}`));
-    console.log(chalk.red(`- Proprietary Format Penalty: ${((1 - report.portabilityScore) * 20).toFixed(1)}`));
+    console.log("Base Score: 100");
+    console.log(
+      chalk.red(
+        `- Vendor Lock-In Penalty: ${(report.lockInScore * 0.5).toFixed(1)}`,
+      ),
+    );
+    console.log(
+      chalk.red(
+        `- Deplatforming Risk Penalty: ${(report.deplatformingRiskScore * 0.3).toFixed(1)}`,
+      ),
+    );
+    console.log(
+      chalk.red(
+        `- Proprietary Format Penalty: ${((1 - report.portabilityScore) * 20).toFixed(1)}`,
+      ),
+    );
     console.log(chalk.bold(`= Freedom Score: ${report.freedomScore}`));
 
     // Separator
@@ -75,14 +99,18 @@ export async function displayReport(
 
     // Real-World Wake-Up Calls
     console.log(chalk.bold("Real-World Wake-Up Calls:"));
-    report.deplatformingExamples.forEach((ex) => console.log(chalk.yellow(`- ${ex}`)));
+    for (const ex of report.deplatformingExamples) {
+      console.log(chalk.yellow(`- ${ex}`));
+    }
 
     // Separator
     console.log(chalk.dim("—".repeat(50)));
 
     // Escape Plan
     console.log(chalk.bold("Escape Plan:"));
-    report.recommendations.forEach((rec) => console.log(`- ${rec}`));
+    for (const rec of report.recommendations) {
+      console.log(`- ${rec}`);
+    }
   } catch (err) {
     throw new Error(`Failed to display report: ${(err as Error).message}`);
   }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -30,7 +30,9 @@ interface ScanOptions {
  * @returns A promise resolving to the scan results, including Freedom Score, risks, and recommendations.
  * @throws Error if scanning fails, no files are found, or patterns are invalid.
  */
-export async function scanCodebase(options: ScanOptions = {}): Promise<ScanResults> {
+export async function scanCodebase(
+  options: ScanOptions = {},
+): Promise<ScanResults> {
   const rootDir = options.dir || process.cwd();
   const verbose = options.verbose || process.env.VERBOSE === "true";
   const defaultPatterns = [
@@ -45,9 +47,10 @@ export async function scanCodebase(options: ScanOptions = {}): Promise<ScanResul
     "!build/**",
     "!vendor/**",
   ];
-  const patterns = options.filePatterns?.map(p => p.trim()) ||
-                   process.env.FILE_PATTERNS?.split(",").map(p => p.trim()) ||
-                   defaultPatterns;
+  const patterns =
+    options.filePatterns?.map((p) => p.trim()) ||
+    process.env.FILE_PATTERNS?.split(",").map((p) => p.trim()) ||
+    defaultPatterns;
 
   if (verbose) {
     console.log(chalk.dim(`Scanning directory: ${rootDir}`));
@@ -58,20 +61,28 @@ export async function scanCodebase(options: ScanOptions = {}): Promise<ScanResul
     const files = await globby(patterns, { cwd: rootDir, gitignore: true });
     if (!files.length) {
       throw new Error(
-        `No infrastructure files found in ${rootDir}. Ensure files match patterns (${patterns.join(", ")}) or check your .env FILE_PATTERNS.`
+        `No infrastructure files found in ${rootDir}. Ensure files match patterns (${patterns.join(", ")}) or check your .env FILE_PATTERNS.`,
       );
     }
     if (verbose || process.env.DEBUG === "true") {
-      console.log(chalk.dim(`Found ${files.length} files: ${files.join(", ")}`));
+      console.log(
+        chalk.dim(`Found ${files.length} files: ${files.join(", ")}`),
+      );
       if (process.env.DEBUG === "true") {
-        console.log(chalk.dim(`Excluded directories: node_modules, dist, build, vendor`));
+        console.log(
+          chalk.dim("Excluded directories: node_modules, dist, build, vendor"),
+        );
       }
     }
     return await analyzeFiles(files, rootDir);
   } catch (err) {
     if (err instanceof Error && err.message.includes("Invalid glob pattern")) {
-      throw new Error(`Invalid file pattern in ${patterns.join(", ")}. Please check your patterns.`);
+      throw new Error(
+        `Invalid file pattern in ${patterns.join(", ")}. Please check your patterns.`,
+      );
     }
-    throw new Error(`Scanning failed: ${err instanceof Error ? err.message : "Unknown error"}`);
+    throw new Error(
+      `Scanning failed: ${err instanceof Error ? err.message : "Unknown error"}`,
+    );
   }
 }


### PR DESCRIPTION
## Summary
- extract parsing helpers from `analyzer.ts`
- use the new `parsers.ts`
- add file header comments for new helpers
- fix lint issues and use `node:` protocol imports

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_684a5be3ee4c832db116c78b61de5173