### PR TITLE
Add static fixtures for tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+tests/fixtures/
+

--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ Run tests:
 npm test
 ```
 
+### Using Test Fixtures
+
+Small infrastructure examples live under `tests/fixtures`. Run the scanner on
+this directory to see a sample report:
+
+```bash
+tmrw audit tests/fixtures
+```
+
+The fixtures include Terraform, Serverless YAML, CloudFormation, and a
+`package.json` with `aws-sdk` so both manual and automated tests have stable
+inputs.
+
 ## License
 
 MIT License  

--- a/tests/analyzer.test.ts
+++ b/tests/analyzer.test.ts
@@ -28,20 +28,27 @@ describe("analyzer", () => {
     expect(results).toHaveProperty("deplatformingExamples");
   });
 
-  it("parses serverless YAML with function objects", async () => {
-    const fs = require("node:fs");
+  it("parses fixture YAML for functions", async () => {
     const path = require("node:path");
-    const tmpDir = fs.mkdtempSync(path.join(process.cwd(), "srvless-"));
-    const yamlPath = path.join(tmpDir, "serverless.yml");
-    fs.writeFileSync(
-      yamlPath,
-      "provider:\n  name: aws\nfunctions:\n  hello:\n    handler: index.handler\n"
-    );
-
-    const results = await analyzeFiles(["serverless.yml"], tmpDir);
+    const fixtureDir = path.join(__dirname, "fixtures");
+    const results = await analyzeFiles(["serverless.yml"], fixtureDir);
 
     expect(results.vendorServices).toContain("aws_lambda_function");
+  });
 
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+  it("parses multiple fixture files", async () => {
+    const path = require("node:path");
+    const fixtureDir = path.join(__dirname, "fixtures");
+    const files = [
+      "main.tf",
+      "serverless.yml",
+      "cfn-template.json",
+      "package.json",
+    ];
+    const results = await analyzeFiles(files, fixtureDir);
+
+    expect(results.providers).toContain("aws");
+    expect(results.vendorServices).toContain("aws_lambda_function");
+    expect(results.vendorServices).toContain("aws_s3_bucket");
   });
 });

--- a/tests/fixtures/Dockerfile
+++ b/tests/fixtures/Dockerfile
@@ -1,0 +1,2 @@
+FROM node:18-alpine
+CMD ["node"]

--- a/tests/fixtures/cfn-template.json
+++ b/tests/fixtures/cfn-template.json
@@ -1,0 +1,7 @@
+{
+  "Resources": {
+    "MyBucket": {
+      "Type": "AWS::S3::Bucket"
+    }
+  }
+}

--- a/tests/fixtures/main.tf
+++ b/tests/fixtures/main.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "bucket" {
+  bucket = "my-test-bucket"
+}

--- a/tests/fixtures/package.json
+++ b/tests/fixtures/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "fixture",
+  "dependencies": {
+    "aws-sdk": "^2.0.0"
+  }
+}

--- a/tests/fixtures/serverless.yml
+++ b/tests/fixtures/serverless.yml
@@ -1,0 +1,6 @@
+provider:
+  name: aws
+  runtime: nodejs14.x
+functions:
+  hello:
+    handler: handler.hello


### PR DESCRIPTION
## Summary
- add infrastructure fixtures under `tests/fixtures`
- update analyzer and scanner tests to use fixtures
- document fixtures usage in README
- add `.npmignore` to exclude fixtures from npm package

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684a5f5a3ffc832db53e5f034e5494f4